### PR TITLE
C2PA-137: Duplicate mime-type

### DIFF
--- a/packages/c2pa/src/lib/validator.ts
+++ b/packages/c2pa/src/lib/validator.ts
@@ -27,7 +27,7 @@ export class Validator {
     'application/x-font-truetype',
     'font/otf',
     'font/sfnt',
-    'font/otf',
+    'font/ttf',
     'image/jpeg',
     'image/png',
     'application/x-c2pa-manifest-store',

--- a/packages/toolkit/Cargo.lock
+++ b/packages/toolkit/Cargo.lock
@@ -254,7 +254,7 @@ checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
 [[package]]
 name = "c2pa"
 version = "0.21.0"
-source = "git+https://github.com/Monotype/c2pa-rs?branch=fix/C2PA-137/duplicateMimeType#edf14f8deee2f906b8ccf187167805284618c1ae"
+source = "git+https://github.com/Monotype/c2pa-rs?branch=monotype/fontSupport#fd22030d94f40d74e34b48a10524378743c1b64e"
 dependencies = [
  "asn1-rs",
  "async-trait",

--- a/packages/toolkit/Cargo.lock
+++ b/packages/toolkit/Cargo.lock
@@ -254,7 +254,7 @@ checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
 [[package]]
 name = "c2pa"
 version = "0.21.0"
-source = "git+https://github.com/Monotype/c2pa-rs?branch=monotype/fontSupport#25a9c240788633393bb1526ff0d54de5f4504dee"
+source = "git+https://github.com/Monotype/c2pa-rs?branch=fix/C2PA-137/duplicateMimeType#edf14f8deee2f906b8ccf187167805284618c1ae"
 dependencies = [
  "asn1-rs",
  "async-trait",

--- a/packages/toolkit/Cargo.toml
+++ b/packages/toolkit/Cargo.toml
@@ -9,7 +9,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 #c2pa = { version = "0.18.1", features = ["serialize_thumbnails"] }
-c2pa = { git = "https://github.com/Monotype/c2pa-rs", branch = "fix/C2PA-137/duplicateMimeType", features = ["otf", "serialize_thumbnails"] }
+c2pa = { git = "https://github.com/Monotype/c2pa-rs", branch = "monotype/fontSupport", features = ["otf", "serialize_thumbnails"] }
 console_error_panic_hook = "0.1.7"
 console_log = { version = "1.0.0", features = ["color"] }
 log = "0.4.14"

--- a/packages/toolkit/Cargo.toml
+++ b/packages/toolkit/Cargo.toml
@@ -9,7 +9,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 #c2pa = { version = "0.18.1", features = ["serialize_thumbnails"] }
-c2pa = { git = "https://github.com/Monotype/c2pa-rs", branch = "monotype/fontSupport", features = ["otf", "serialize_thumbnails"] }
+c2pa = { git = "https://github.com/Monotype/c2pa-rs", branch = "fix/C2PA-137/duplicateMimeType", features = ["otf", "serialize_thumbnails"] }
 console_error_panic_hook = "0.1.7"
 console_log = { version = "1.0.0", features = ["color"] }
 log = "0.4.14"


### PR DESCRIPTION
<!--  Title should use the format: "JIRA-123: Summary of change"   -->
<!--     Branch names for Stories: "feature/JIRA-123/featureName"  -->
<!--        Branch names for Bugs: "fix/JIRA-123/bugFixName"       -->
# JIRA Issue

- C2PA-137

# Checklist
<!--  Replace the ' ' with an 'x' for each that applies:  -->
- [x] **PR labeled** appropriately
- [ ] **Documentation** updated:
  - [ ] Developer documentation (ReadMe files)
  - [ ] Product documentation (Release notes, PDK Guide, Functional Spec, API documents, ...)
- [ ] **Test case(s)** added
  - [ ] Unit Tests

# Notes for Reviewers

I had a typo on the mime-types, had two `font/otf` and missing `font/ttf`. This addresses that issue.

<!--  Information to assist code reviewers:                    -->
<!--    Dependencies or co-reqs (other branches, other repos)  -->
<!--    Limitations and/or breakage.                           -->

# Verification Instructions
<!-- Instructions for checking or testing this change. -->

Should be able to use mimetype `font/ttf` when verifying with the with font support. For setup instructions, refer to https://github.com/Monotype/c2pa-js/pull/1.


> NOTE: Once the c2pa-rs is approved, I will need to push a change to update the reference to the `monotype/fontSupport` branch.


> Actively maintained by the @Monotype/driverpdldev team.
